### PR TITLE
Fix video sources not showing

### DIFF
--- a/src/plugin.video.icdrama/lib/resolvers/videobug.py
+++ b/src/plugin.video.icdrama/lib/resolvers/videobug.py
@@ -22,8 +22,10 @@ class Videobug(UrlResolver):
 
     def get_media_url(self, host, media_id):
         url = self.get_url(host, media_id)
+        headers = self.headers
+        headers['Referer'] = 'http://icdrama.se'
 
-        response = requests.get(url, headers = self.headers)
+        response = requests.get(url, headers=headers)
         streams = self._extract_streams(response)
         url = helpers.pick_source(streams, auto_pick=False)
 


### PR DESCRIPTION
Quickfix for showing video sources. Source videobug.se has changed and is redirecting requests which doesn't come from icdrama.se.