### PR TITLE
Update domain list for url resolving

### DIFF
--- a/src/plugin.video.icdrama/lib/resolvers/videobug.py
+++ b/src/plugin.video.icdrama/lib/resolvers/videobug.py
@@ -12,8 +12,8 @@ from urlresolver.plugins.lib import jsunpack, helpers
 
 class Videobug(UrlResolver):
     name = 'Videobug'
-    domains = [ 'videobug.se' ]
-    pattern = '(?://|\.)(videobug\.se)/(.+)'
+    domains = [ 'videobug.se', 'vlist.se']
+    pattern = '(?://|\.)(videobug\.se|vlist\.se)/(.+)'
 
     def __init__(self):
         self.net = common.Net()


### PR DESCRIPTION
Icdrama is using a new domain for video hosting. The existing resolver has been extended with the new domain to fix the problem.